### PR TITLE
correct package name in npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Axiom observability middleware for Prisma.
 1. Install prisma-axiom
 
 ```shell
-npm install --save prisma-axiom
+npm install --save @axiomhq/axiom-prisma
 ```
 
 2. Add the following where you initialize your Prisma client:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install --save @axiomhq/axiom-prisma
 2. Add the following where you initialize your Prisma client:
 
 ```ts
-import withAxiom from 'prisma-axiom';
+import withAxiom from '@axiomhq/axiom-prisma';
 const prisma = withAxiom(new PrismaClient());
 ```
 


### PR DESCRIPTION
Command that was in guide pointed to a package that does not exist: 

![image](https://user-images.githubusercontent.com/11494384/190002087-3ad069da-e8f8-4181-8f9c-99e95dfa39f5.png)
